### PR TITLE
Removing old version link, which is dead

### DIFF
--- a/src/app/shared/menu-bar/menu-bar.component.html
+++ b/src/app/shared/menu-bar/menu-bar.component.html
@@ -18,9 +18,6 @@
     <li class="nav-item">
       <a class="nav-link" href="https://github.com/Azure/azure-quickstart-templates" target="_blank">Quickstarts</a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link" href="http://old.armviz.io" target="_blank">Looking for the previous version?</a>
-    </li>
 
     <!--<li class="nav-item">
       <div ngbDropdown>


### PR DESCRIPTION
http://old.armviz.io 404's.  
This PR removes the dead link